### PR TITLE
Add line to map fivetran_connector_schedule to Pulumi provider

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,11 +2,11 @@
 
 To release a new version:
 
-1. Make changes.
+1. Make changes and verify with `make`.
 
 2. Commit changes and push to GitHub.
 
-3. Create the tag.
+3. Merge the PR and create the tag.
 
     ```
     version=vA.B.C

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -91,6 +91,7 @@ func Provider(version string) tfbridge.ProviderInfo {
 					},
 				},
 			},
+			"fivetran_connector_schedule":  {Tok: makeResource(mainMod, "ConnectorSchedule")},
 			"fivetran_connector_schema_config": {Tok: makeResource(mainMod, "ConnectorSchemaConfig")},
 		},
 		DataSources: map[string]*tfbridge.DataSourceInfo{


### PR DESCRIPTION
This PR follows #5 , aiming to fix the build. 

<img width="1050" alt="image" src="https://github.com/MaterializeInc/pulumi-fivetran/assets/819476/082a3f6a-d6df-4ec0-980d-233fd7a356ed">

The past build [failed](https://github.com/MaterializeInc/pulumi-fivetran/actions/runs/5416339413) with the following error:

```
error: failed to gather package metadata: problem gathering resources: 1 error occurred:
	* TF resource "fivetran_connector_schedule" not mapped to the Pulumi provider


make: *** [Makefile:10: cmd/pulumi-resource-fivetran/schema.json] Error 255
Error: Process completed with exit code 2.
```

I hadn't previously run `make` before opening my PR. I did so and reproduced the problem locally. 

<img width="1178" alt="image" src="https://github.com/MaterializeInc/pulumi-fivetran/assets/819476/7b5ff774-5a8b-4d4c-bc2d-06d54ed3905c">

I added this line based on the diff I saw in https://github.com/MaterializeInc/pulumi-fivetran/commit/d222c1d72cb19e7aa6bc8604ea29028bc42cddd9 and confirmed it work by running `make` again.

<img width="1512" alt="image" src="https://github.com/MaterializeInc/pulumi-fivetran/assets/819476/f4a39af2-efa7-4417-b4ae-10346a8dc38a">